### PR TITLE
ci: a new path for download apisix-build.sh

### DIFF
--- a/.github/workflows/apisix-test.yml
+++ b/.github/workflows/apisix-test.yml
@@ -15,9 +15,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install deps
       run: |
-        wget https://raw.githubusercontent.com/api7/apisix-build-tools/master/build-apisix-openresty.sh
-        chmod +x build-apisix-openresty.sh
-        ./build-apisix-openresty.sh latest
+        wget https://raw.githubusercontent.com/api7/apisix-build-tools/master/build-apisix-base.sh
+        chmod +x build-apisix-base.sh
+        ./build-apisix-base.sh latest
 
     - name: Install CPAN
       run: |


### PR DESCRIPTION
fix https://github.com/api7/lua-resty-http/issues/15

